### PR TITLE
複数カメラのCulling対応

### DIFF
--- a/Assets/Example/GpuTrailCullingAndLodExample.unity
+++ b/Assets/Example/GpuTrailCullingAndLodExample.unity
@@ -104,7 +104,7 @@ NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
-    serializedVersion: 2
+    serializedVersion: 3
     agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
@@ -117,7 +117,7 @@ NavMeshSettings:
     cellSize: 0.16666666
     manualTileSize: 0
     tileSize: 256
-    accuratePlacement: 0
+    buildHeightMesh: 0
     maxJobWorkers: 0
     preserveTilesOutsideBounds: 0
     debug:
@@ -135,6 +135,7 @@ GameObject:
   - component: {fileID: 104940729}
   - component: {fileID: 104940727}
   - component: {fileID: 104940726}
+  - component: {fileID: 104940731}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -172,9 +173,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -211,11 +220,55 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -100}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 911709187}
   m_Father: {fileID: 310526803}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &104940731
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 104940725}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    quality: 3
+    frameInfluence: 0.1
+    jitterScale: 1
+    mipBias: 0
+    varianceClampScale: 0.9
+    contrastAdaptiveSharpening: 0
 --- !u!1 &310526802
 GameObject:
   m_ObjectHideFlags: 0
@@ -243,6 +296,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -25, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 104940730}
   m_Father: {fileID: 0}
@@ -287,6 +341,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1128910013}
   - {fileID: 928204800}
@@ -305,6 +360,7 @@ GameObject:
   m_Component:
   - component: {fileID: 928204800}
   - component: {fileID: 928204804}
+  - component: {fileID: 928204805}
   m_Layer: 0
   m_Name: Camera2
   m_TagString: Untagged
@@ -322,6 +378,7 @@ Transform:
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 911709187}
   m_RootOrder: 1
@@ -340,9 +397,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -369,6 +434,49 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
+--- !u!114 &928204805
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 928204799}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    quality: 3
+    frameInfluence: 0.1
+    jitterScale: 1
+    mipBias: 0
+    varianceClampScale: 0.9
+    contrastAdaptiveSharpening: 0
 --- !u!1 &1043586158
 GameObject:
   m_ObjectHideFlags: 0
@@ -379,6 +487,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1043586159}
   - component: {fileID: 1043586163}
+  - component: {fileID: 1043586164}
   m_Layer: 0
   m_Name: Camera4
   m_TagString: Untagged
@@ -396,6 +505,7 @@ Transform:
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 911709187}
   m_RootOrder: 3
@@ -414,9 +524,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -443,6 +561,49 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
+--- !u!114 &1043586164
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1043586158}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    quality: 3
+    frameInfluence: 0.1
+    jitterScale: 1
+    mipBias: 0
+    varianceClampScale: 0.9
+    contrastAdaptiveSharpening: 0
 --- !u!1 &1128910012
 GameObject:
   m_ObjectHideFlags: 0
@@ -453,6 +614,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1128910013}
   - component: {fileID: 1128910017}
+  - component: {fileID: 1128910018}
   m_Layer: 0
   m_Name: Camera1
   m_TagString: Untagged
@@ -470,6 +632,7 @@ Transform:
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 911709187}
   m_RootOrder: 0
@@ -488,9 +651,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -517,6 +688,49 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
+--- !u!114 &1128910018
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1128910012}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    quality: 3
+    frameInfluence: 0.1
+    jitterScale: 1
+    mipBias: 0
+    varianceClampScale: 0.9
+    contrastAdaptiveSharpening: 0
 --- !u!1 &1844795434
 GameObject:
   m_ObjectHideFlags: 0
@@ -527,6 +741,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1844795435}
   - component: {fileID: 1844795439}
+  - component: {fileID: 1844795440}
   m_Layer: 0
   m_Name: Camera3
   m_TagString: Untagged
@@ -544,6 +759,7 @@ Transform:
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: -0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 911709187}
   m_RootOrder: 2
@@ -562,9 +778,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -591,6 +815,49 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
+--- !u!114 &1844795440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1844795434}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    quality: 3
+    frameInfluence: 0.1
+    jitterScale: 1
+    mipBias: 0
+    varianceClampScale: 0.9
+    contrastAdaptiveSharpening: 0
 --- !u!1 &1927869132
 GameObject:
   m_ObjectHideFlags: 0
@@ -624,17 +891,18 @@ MonoBehaviour:
   gpuTrail:
     trailNum: 1
     life: 7
-    inputPerSec: 60
+    inputPerSec: 30
     minNodeDistance: 0.1
   appendNodeCS: {fileID: 7200000, guid: d1a2d7e60a9bbd54e8a06cea0893efff, type: 3}
   colorEnable: 0
   ignoreOriginInput: 1
+  inputCountMax: 1
   gizmosSize: 0.5
   gizmosDrawInputPos: 0
   gizmosDrawNodePos: 0
   particle:
     particleCS: {fileID: 7200000, guid: 16daaa733f6a1194394beb0d2f0d6fb9, type: 3}
-    particleNum: 10000
+    particleNum: 50000
     startSpeed: 1
     forceRate: 0.15
     damping: 0.95
@@ -651,6 +919,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -676,6 +945,9 @@ MonoBehaviour:
   startWidth: 0.05
   endWidth: 0.02
   targetCamera: {fileID: 0}
+  bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 50000, y: 50000, z: 50000}
   lodSettings:
   - enable: 1
     startDistance: 0
@@ -700,7 +972,7 @@ LightingSettings:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Settings.lighting
-  serializedVersion: 3
+  serializedVersion: 6
   m_GIWorkflowMode: 1
   m_EnableBakedLightmaps: 1
   m_EnableRealtimeLightmaps: 0
@@ -709,11 +981,11 @@ LightingSettings:
   m_AlbedoBoost: 1
   m_IndirectOutputScale: 1
   m_UsingShadowmask: 0
-  m_BakeBackend: 0
+  m_BakeBackend: 1
   m_LightmapMaxSize: 1024
   m_BakeResolution: 50
   m_Padding: 2
-  m_TextureCompression: 0
+  m_LightmapCompression: 0
   m_AO: 0
   m_AOMaxDistance: 1
   m_CompAOExponent: 0
@@ -734,13 +1006,13 @@ LightingSettings:
   m_PVRCulling: 1
   m_PVRSampling: 1
   m_PVRDirectSampleCount: 32
-  m_PVRSampleCount: 500
-  m_PVREnvironmentSampleCount: 500
+  m_PVRSampleCount: 512
+  m_PVREnvironmentSampleCount: 512
   m_PVREnvironmentReferencePointCount: 2048
   m_LightProbeSampleCountMultiplier: 4
   m_PVRBounces: 2
   m_PVRMinBounces: 2
-  m_PVREnvironmentMIS: 0
+  m_PVREnvironmentImportanceSampling: 0
   m_PVRFilteringMode: 0
   m_PVRDenoiserTypeDirect: 0
   m_PVRDenoiserTypeIndirect: 0
@@ -754,3 +1026,6 @@ LightingSettings:
   m_PVRFilteringAtrousPositionSigmaDirect: 0.5
   m_PVRFilteringAtrousPositionSigmaIndirect: 2
   m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_PVRTiledBaking: 0
+  m_NumRaysToShootPerTexel: -1
+  m_RespectSceneVisibilityWhenBakingGI: 0

--- a/Assets/Example/GpuTrailCullingAndLodExample.unity
+++ b/Assets/Example/GpuTrailCullingAndLodExample.unity
@@ -217,6 +217,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 104940725}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -100}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -224,7 +225,6 @@ Transform:
   m_Children:
   - {fileID: 911709187}
   m_Father: {fileID: 310526803}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &104940731
 MonoBehaviour:
@@ -256,6 +256,7 @@ MonoBehaviour:
   m_Dithering: 0
   m_ClearDepth: 1
   m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
   m_UseScreenCoordOverride: 0
   m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
   m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
@@ -293,6 +294,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 310526802}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -25, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -300,7 +302,6 @@ Transform:
   m_Children:
   - {fileID: 104940730}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &310526804
 MonoBehaviour:
@@ -338,6 +339,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 911709186}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -348,7 +350,6 @@ Transform:
   - {fileID: 1844795435}
   - {fileID: 1043586159}
   m_Father: {fileID: 104940730}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &928204799
 GameObject:
@@ -375,13 +376,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 928204799}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 911709187}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!20 &928204804
 Camera:
@@ -464,6 +465,7 @@ MonoBehaviour:
   m_Dithering: 0
   m_ClearDepth: 1
   m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
   m_UseScreenCoordOverride: 0
   m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
   m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
@@ -502,13 +504,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1043586158}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 911709187}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!20 &1043586163
 Camera:
@@ -591,6 +593,7 @@ MonoBehaviour:
   m_Dithering: 0
   m_ClearDepth: 1
   m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
   m_UseScreenCoordOverride: 0
   m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
   m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
@@ -629,13 +632,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1128910012}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 911709187}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!20 &1128910017
 Camera:
@@ -718,6 +721,7 @@ MonoBehaviour:
   m_Dithering: 0
   m_ClearDepth: 1
   m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
   m_UseScreenCoordOverride: 0
   m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
   m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
@@ -756,13 +760,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1844795434}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: -0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 911709187}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 270, z: 0}
 --- !u!20 &1844795439
 Camera:
@@ -845,6 +849,7 @@ MonoBehaviour:
   m_Dithering: 0
   m_ClearDepth: 1
   m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
   m_UseScreenCoordOverride: 0
   m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
   m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
@@ -890,7 +895,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gpuTrail:
     trailNum: 1
-    life: 7
+    life: 3
     inputPerSec: 30
     minNodeDistance: 0.1
   appendNodeCS: {fileID: 7200000, guid: d1a2d7e60a9bbd54e8a06cea0893efff, type: 3}
@@ -902,7 +907,7 @@ MonoBehaviour:
   gizmosDrawNodePos: 0
   particle:
     particleCS: {fileID: 7200000, guid: 16daaa733f6a1194394beb0d2f0d6fb9, type: 3}
-    particleNum: 50000
+    particleNum: 100000
     startSpeed: 1
     forceRate: 0.15
     damping: 0.95
@@ -916,13 +921,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1927869132}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1927869135
 MonoBehaviour:
@@ -1029,3 +1034,9 @@ LightingSettings:
   m_PVRTiledBaking: 0
   m_NumRaysToShootPerTexel: -1
   m_RespectSceneVisibilityWhenBakingGI: 0
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 310526803}
+  - {fileID: 1927869134}

--- a/Assets/URP/Universal Render Pipeline Asset_Renderer.asset
+++ b/Assets/URP/Universal Render Pipeline Asset_Renderer.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   debugShaders:
     debugReplacementPS: {fileID: 4800000, guid: cf852408f2e174538bcd9b7fda1c5ae7,
       type: 3}
+    hdrDebugViewPS: {fileID: 4800000, guid: 573620ae32aec764abd4d728906d2587, type: 3}
   m_RendererFeatures: []
   m_RendererFeatureMap: 
   m_UseNativeRenderPass: 0
@@ -32,9 +33,12 @@ MonoBehaviour:
     coreBlitPS: {fileID: 4800000, guid: 93446b5c5339d4f00b85c159e1159b7c, type: 3}
     coreBlitColorAndDepthPS: {fileID: 4800000, guid: d104b2fc1ca6445babb8e90b0758136b,
       type: 3}
+    blitHDROverlay: {fileID: 4800000, guid: a89bee29cffa951418fc1e2da94d1959, type: 3}
     cameraMotionVector: {fileID: 4800000, guid: c56b7e0d4c7cb484e959caeeedae9bbf,
       type: 3}
     objectMotionVector: {fileID: 4800000, guid: 7b3ede40266cd49a395def176e1bc486,
+      type: 3}
+    dataDrivenLensFlare: {fileID: 4800000, guid: 6cda457ac28612740adb23da5d39ea92,
       type: 3}
   m_AssetVersion: 2
   m_OpaqueLayerMask:

--- a/Packages/GpuTrail/Scripts/GpuTrail.cs
+++ b/Packages/GpuTrail/Scripts/GpuTrail.cs
@@ -63,8 +63,7 @@ namespace GpuTrailSystem
         protected virtual void InitBuffer()
         {
             TrailBuffer = new GraphicsBuffer(GraphicsBuffer.Target.Structured, trailNum, Marshal.SizeOf<Trail>());
-            TrailBuffer.Fill(default(Trail));
-
+            TrailBuffer.Fill(new Trail(){frameCount = -1, selectedLod = -1});
             NodeBuffer = new GraphicsBuffer(GraphicsBuffer.Target.Structured, NodeNumTotal, Marshal.SizeOf<Node>());
             NodeBuffer.Fill(default(Node));
         }

--- a/Packages/GpuTrail/Scripts/GpuTrailRenderer.cs
+++ b/Packages/GpuTrail/Scripts/GpuTrailRenderer.cs
@@ -72,9 +72,8 @@ namespace GpuTrailSystem
 
         protected GpuTrail GpuTrail => gpuTrailAppendNode.GpuTrail;
         protected virtual Camera TargetCamera => targetCamera != null ? targetCamera : Camera.main;
-
-        protected bool IsNoCulling => (targetCamera == null  && !cullingEnable);
         
+        protected Vector3 lastCameraPos;
         #region Unity
 
         protected virtual void Start()
@@ -109,7 +108,7 @@ namespace GpuTrailSystem
                 gpuTrailAppendNode.AppendNode();
             }
 
-            if (IsNoCulling)
+            if (targetCamera == null  && !cullingEnable)
             {
                 UpdateVertex(TargetCamera);
                 Render(TargetCamera);
@@ -171,13 +170,16 @@ namespace GpuTrailSystem
             // UpdateVertex
             if (updateVertexEnable)
             {
+                // Force update when camera position change
+                var isForceUpdate = Vector3.Distance(lastCameraPos, camera.transform.position) > float.Epsilon;
                 Profiler.BeginSample("GpuTrailRenderer.UpdateVertexBuffer");
                 ForeachLod((lod, idx) =>
                 {
                     var trailIndexBuffer = trailIndexBuffersLod?[idx] ?? trailIndexBufferCulling;
-                    lod.UpdateVertexBuffer(camera, startWidth, endWidth, trailIndexBuffer);
+                    lod.UpdateVertexBuffer(camera, startWidth, endWidth, isForceUpdate, trailIndexBuffer);
                 });
                 Profiler.EndSample();
+                lastCameraPos = camera.transform.position;
             }
             
 

--- a/Packages/GpuTrail/Scripts/GpuTrailRenderer.cs
+++ b/Packages/GpuTrail/Scripts/GpuTrailRenderer.cs
@@ -239,6 +239,19 @@ namespace GpuTrailSystem
             lodList.Clear();
         }
 
+        protected bool IsCullingRenderTarget(Camera cam)
+        {
+            if (lodSettings.Count != lodList.Count) ResetLodList();
+
+            if(targetCamera != null && targetCamera != cam)
+                return false;
+
+            if((cam.cullingMask & (1 << gameObject.layer)) == 0)
+                return false;
+
+            return cullingEnable;
+        }
+        
         /// <summary>
         /// カメラごとのレンダリング前のカリング処理(カリング有効時のみ) for URP/HDRP
         /// Per-camera pre-render culling for URP/HDRP
@@ -247,16 +260,7 @@ namespace GpuTrailSystem
         /// <param name="cam"></param>
         protected virtual void OnBeginCameraRendering(ScriptableRenderContext context, Camera cam)
         {
-            if (lodSettings.Count != lodList.Count) ResetLodList();
-
-            if(targetCamera != null && targetCamera != cam)
-                return;
-
-            var layer = 1 << gameObject.layer;
-            if((cam.cullingMask & layer) == 0)
-                return;
-            
-            if (!cullingEnable)
+            if (!IsCullingRenderTarget(cam))
                 return;
             
             UpdateVertex(cam);
@@ -269,16 +273,9 @@ namespace GpuTrailSystem
         /// Per-camera pre-render culling for Built-in RP
         /// </summary>
         /// <param name="cam"></param>
-        private void OnPreCullCallback(Camera cam)
+        protected virtual void OnPreCullCallback(Camera cam)
         {
-            if(targetCamera != null && targetCamera != cam)
-                return;
-        
-            var layer = 1 << gameObject.layer;
-            if((cam.cullingMask & layer) == 0)
-                return;
-            
-            if (!cullingEnable)
+            if (!IsCullingRenderTarget(cam))
                 return;
             
             UpdateVertex(cam);

--- a/Packages/GpuTrail/Scripts/GpuTrailRendererCalcLod.cs
+++ b/Packages/GpuTrail/Scripts/GpuTrailRendererCalcLod.cs
@@ -13,7 +13,10 @@ namespace GpuTrailSystem
             public static readonly int CameraPos = Shader.PropertyToID("_CameraPos");
             public static readonly int LodDistanceBuffer = Shader.PropertyToID("_LodDistanceBuffer");
             public static readonly int TrailLodBufferW = Shader.PropertyToID("_TrailLodBufferW");
-
+            public static readonly int TrailBuffer = Shader.PropertyToID("_TrailBuffer");
+            public static readonly int ForceUpdate = Shader.PropertyToID("_ForceUpdate");
+            public static readonly int FrameCount = Shader.PropertyToID("_FrameCount");
+            
             public const string KernelUpdateTrailIndexBuffer = "UpdateTrailIndexBuffer";
             public static readonly int CurrentLod = Shader.PropertyToID("_CurrentLod");
             public static readonly int TrailLodBuffer = Shader.PropertyToID("_TrailLodBuffer");
@@ -66,7 +69,7 @@ namespace GpuTrailSystem
 
 
         // return TrailIndexBuffer in the same order as the lodDistances
-        public virtual IReadOnlyList<GraphicsBuffer> CalcTrailIndexBuffers(IEnumerable<float> lodDistances, Camera camera, GpuTrail gpuTrail, GraphicsBuffer trailIndexBuffer)
+        public virtual IReadOnlyList<GraphicsBuffer> CalcTrailIndexBuffers(IEnumerable<float> lodDistances, Camera camera, GpuTrail gpuTrail, GraphicsBuffer trailIndexBuffer, bool forceUpdate)
         {
             var idxAndDistances = lodDistances
                 .Select((distance, idx) => (idx, distance))
@@ -80,7 +83,7 @@ namespace GpuTrailSystem
 
             UpdateTrailLodBuffer(
                  idxAndDistances.Select(pair => pair.distance).ToArray(),
-                 camera, gpuTrail, trailIndexBuffer
+                 camera, gpuTrail, trailIndexBuffer, forceUpdate
                 );
 
             UpdateTrailIndexBuffers(
@@ -93,7 +96,7 @@ namespace GpuTrailSystem
         }
 
 
-        protected void UpdateTrailLodBuffer(float[] sortedDistances, Camera camera, GpuTrail gpuTrail, GraphicsBuffer trailIndexBuffer)
+        protected void UpdateTrailLodBuffer(float[] sortedDistances, Camera camera, GpuTrail gpuTrail, GraphicsBuffer trailIndexBuffer, bool forceUpdate)
         {
             lodDistanceBuffer.SetData(sortedDistances);
 
@@ -102,7 +105,10 @@ namespace GpuTrailSystem
             calcLodCs.SetVector(CsParam.CameraPos, camera.transform.position);
             calcLodCs.SetBuffer(kernel, CsParam.LodDistanceBuffer, lodDistanceBuffer);
             calcLodCs.SetBuffer(kernel, CsParam.TrailLodBufferW, trailLodBuffer);
-
+            calcLodCs.SetBuffer(kernel, CsParam.TrailBuffer, gpuTrail.TrailBuffer);
+            calcLodCs.SetBool(CsParam.ForceUpdate, forceUpdate);
+            calcLodCs.SetInt(CsParam.FrameCount, Time.frameCount);
+            
             if (trailIndexBuffer != null)
             {
                 gpuTrailIndexArgs.Dispatch(calcLodCs, kernel, trailIndexBuffer);

--- a/Packages/GpuTrail/Scripts/GpuTrailRendererCulling.cs
+++ b/Packages/GpuTrail/Scripts/GpuTrailRendererCulling.cs
@@ -24,6 +24,8 @@ namespace GpuTrailSystem
 
         public GpuTrailRendererCulling(ComputeShader cullingCs) => this.cullingCs = cullingCs;
 
+        private Plane[] planes = new Plane[6];
+        
         public void Dispose()
         {
             ReleaseBuffer();
@@ -54,7 +56,7 @@ namespace GpuTrailSystem
                 cameraPos += cameraTrans.rotation * debugCameraPosLocalOffset;
             }
 
-            var planes = GeometryUtility.CalculateFrustumPlanes(camera);
+            GeometryUtility.CalculateFrustumPlanes(camera, planes);
             var normals = planes.Take(4).Select(p => p.normal).ToList();
             var normalsFloat = Enumerable.Range(0, 3).SelectMany(i => normals.Select(n => n[i])).ToArray(); // row major -> column major
 

--- a/Packages/GpuTrail/Scripts/GpuTrailRendererCulling.cs
+++ b/Packages/GpuTrail/Scripts/GpuTrailRendererCulling.cs
@@ -69,10 +69,9 @@ namespace GpuTrailSystem
             cullingCs.SetBuffer(kernel, CsParam.TrailIndexBufferAppend, trailIndexBuffer);
 
             ComputeShaderUtility.Dispatch(cullingCs, kernel, gpuTrail.trailNum);
-
-            return trailIndexBuffer;
-
+            
 #if true
+            return trailIndexBuffer;
         }
 #else
             if (tmpBuf == null)
@@ -82,9 +81,11 @@ namespace GpuTrailSystem
             GraphicsBuffer.CopyCount(trailIndexBuffer, tmpBuf, 0);
             var count = new uint[1];
             tmpBuf.GetData(count);
-            Debug.Log(count.First());
+            Debug.Log($"{camera.name} Culling {count.First()}");
             var trailIdx = new uint[trailIndexBuffer.count];
             trailIndexBuffer.GetData(trailIdx);
+            
+            return trailIndexBuffer;
         }
         GraphicsBuffer tmpBuf;
 #endif

--- a/Packages/GpuTrail/Scripts/GpuTrailRendererLod.cs
+++ b/Packages/GpuTrail/Scripts/GpuTrailRendererLod.cs
@@ -241,7 +241,7 @@ namespace GpuTrailSystem
         }
 
 
-        public void Render(Material material, float startWidth, float endWidth, in Bounds bounds)
+        public void Render(Material material, float startWidth, float endWidth, in Bounds bounds, Camera camera)
         {
             PropertyBlock.SetFloat(ShaderParam.StartWidth, startWidth);
             PropertyBlock.SetFloat(ShaderParam.EndWidth, endWidth);
@@ -252,7 +252,10 @@ namespace GpuTrailSystem
                 matProps = PropertyBlock,
                 worldBounds = bounds
             };
-            
+            if (camera != null)
+            {
+                renderParams.camera = camera;
+            }
             Graphics.RenderPrimitivesIndexedIndirect(renderParams, MeshTopology.Triangles, indexBuffer, argsBuffer);
         }
 

--- a/Packages/GpuTrail/Scripts/GpuTrailRendererLod.cs
+++ b/Packages/GpuTrail/Scripts/GpuTrailRendererLod.cs
@@ -259,6 +259,11 @@ namespace GpuTrailSystem
             if (trailIndexBuffer != null)
             {
                 PropertyBlock.SetBuffer(ShaderParam.TrailIndexBuffer, trailIndexBuffer);
+                material.EnableKeyword("GPUTRAIL_TRAIL_INDEX_ON");
+            }
+            else
+            {
+                material.DisableKeyword("GPUTRAIL_TRAIL_INDEX_ON");
             }
             
             var renderParams = new RenderParams(material)

--- a/Packages/GpuTrail/Scripts/Trail.cs
+++ b/Packages/GpuTrail/Scripts/Trail.cs
@@ -4,5 +4,7 @@ namespace GpuTrailSystem
     {
         public float startTime;
         public int totalInputNum;
+        public int frameCount;
+        public int selectedLod;
     }
 }

--- a/Packages/GpuTrail/Shaders/GpuTrail.shader
+++ b/Packages/GpuTrail/Shaders/GpuTrail.shader
@@ -17,10 +17,13 @@ SubShader {
 
 		#pragma vertex vert
 		#pragma fragment frag
-
+		// #pragma multi_compile_local __ GPUTRAIL_TRAIL_INDEX_ON
+		
 		#include "UnityCG.cginc"
+		#define GPUTRAIL_TRAIL_INDEX_ON
+		#include "GpuTrailIndexInclude.hlsl"
 		#include "GpuTrailShaderInclude.hlsl"
-
+		
 		float4 _StartColor;
 		float4 _EndColor;
 
@@ -33,8 +36,11 @@ SubShader {
 		vs_out vert (uint vId : SV_VertexID, uint iId : SV_InstanceID)
 		{
 			vs_out Out;
-			Vertex vtx = GetVertex(vId, iId);
-
+			// Vertex vtx = GetVertex(vId, iId);
+			uint trainIndex = GetTrailIdx(iId);
+			vId = vId % _VertexNumPerTrail;
+			Vertex vtx = GetVertex(vId, trainIndex);
+			
 			Out.pos = UnityObjectToClipPos(float4(vtx.pos, 1.0));
 			Out.uv = vtx.uv;
 			Out.col = lerp(_EndColor, _StartColor, vtx.uv.x);

--- a/Packages/GpuTrail/Shaders/GpuTrail.shader
+++ b/Packages/GpuTrail/Shaders/GpuTrail.shader
@@ -17,10 +17,11 @@ SubShader {
 
 		#pragma vertex vert
 		#pragma fragment frag
-		// #pragma multi_compile_local __ GPUTRAIL_TRAIL_INDEX_ON
+		#pragma multi_compile_local __ GPUTRAIL_TRAIL_INDEX_ON
 		
 		#include "UnityCG.cginc"
-		#define GPUTRAIL_TRAIL_INDEX_ON
+
+		uint _TrailNum;
 		#include "GpuTrailIndexInclude.hlsl"
 		#include "GpuTrailShaderInclude.hlsl"
 		

--- a/Packages/GpuTrail/Shaders/GpuTrailCSInclude.hlsl
+++ b/Packages/GpuTrail/Shaders/GpuTrailCSInclude.hlsl
@@ -5,6 +5,8 @@ struct Trail
 {
 	float startTime;
 	uint totalInputNum;
+	int frameCount;
+	int selectedLod;
 };
 
 struct Node

--- a/Packages/GpuTrail/Shaders/GpuTrailCalcLod.compute
+++ b/Packages/GpuTrail/Shaders/GpuTrailCalcLod.compute
@@ -12,8 +12,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 float3 _CameraPos;
 StructuredBuffer<Node> _NodeBuffer;
+StructuredBuffer<Trail> _TrailBuffer;
 StructuredBuffer<float> _LodDistanceBuffer; // Order By distance
 RWStructuredBuffer<uint> _TrailLodBufferW;
+int _FrameCount;
+bool _ForceUpdate;
 
 [numthreads(NUM_THREAD_X,1,1)]
 void UpdateTrailLodBuffer (uint3 id : SV_DispatchThreadID)
@@ -23,11 +26,18 @@ void UpdateTrailLodBuffer (uint3 id : SV_DispatchThreadID)
 	{
 		uint trailIdx = GetTrailIdx(trailIdxBufferIdx);
 
+		Trail trail = _TrailBuffer[trailIdx];
+		
+		if(!_ForceUpdate && _FrameCount == trail.frameCount)
+		{
+			return;
+		}
+		
 		float minDistanceSq = -1.0;
 
 		uint nodeIdxStart = calcNodeIdx(trailIdx, 0);
 		uint nodeIdxEnd = nodeIdxStart + _NodeNumPerTrail;
-		for(uint nodeIdx = nodeIdxStart; nodeIdx < nodeIdxEnd; nodeIdx++)
+		for(uint nodeIdx = nodeIdxStart; nodeIdx < nodeIdxEnd; nodeIdx+=2)
 		{
 			Node node = _NodeBuffer[nodeIdx];
 			if ( node.time > 0)

--- a/Packages/GpuTrail/Shaders/GpuTrailCulling.compute
+++ b/Packages/GpuTrail/Shaders/GpuTrailCulling.compute
@@ -20,8 +20,7 @@ void UpdateTrailIdxBuffer (uint3 id : SV_DispatchThreadID)
 	{
 		uint nodeIdxStart = calcNodeIdx(trailIdx, 0);
 		uint nodeIdxEnd = nodeIdxStart + _NodeNumPerTrail;
-		uint nodeIdxEndHalf = nodeIdxStart + _NodeNumPerTrail / 2;
-		for(uint nodeIdx = nodeIdxStart; nodeIdx < nodeIdxEndHalf; nodeIdx++)
+		for(uint nodeIdx = nodeIdxStart; nodeIdx < nodeIdxEnd; nodeIdx++)
 		{
 			Node node = _NodeBuffer[nodeIdx];
 
@@ -29,29 +28,6 @@ void UpdateTrailIdxBuffer (uint3 id : SV_DispatchThreadID)
 			{
 				// CheckCulling!
 				float3 posFromCamera = node.pos - _CameraPos;
-
-				if ( 
-					/*
-					(dot(_CameraFrustumNormals[0], posFromCamera) > -_TrailWidth) 
-					&& (dot(_CameraFrustumNormals[1], posFromCamera) > -_TrailWidth)
-					&& (dot(_CameraFrustumNormals[2], posFromCamera) > -_TrailWidth)
-					&& (dot(_CameraFrustumNormals[3], posFromCamera) > -_TrailWidth)
-					*/
-					all(mul(_CameraFrustumNormals, posFromCamera) > -_TrailWidth)
-				)
-				{
-					_TrailIndexBufferAppend.Append(trailIdx);
-					break;
-				}
-			}
-
-			uint backIdx = nodeIdxEnd - 1 - (nodeIdx - nodeIdxStart);
-			Node nodeBack = _NodeBuffer[backIdx];
-
-			if(nodeBack.time > 0)
-			{
-				// CheckCulling!
-				float3 posFromCamera = nodeBack.pos - _CameraPos;
 
 				if ( 
 					/*

--- a/Packages/GpuTrail/Shaders/GpuTrailCulling.compute
+++ b/Packages/GpuTrail/Shaders/GpuTrailCulling.compute
@@ -45,7 +45,7 @@ void UpdateTrailIdxBuffer (uint3 id : SV_DispatchThreadID)
 				}
 			}
 
-			uint backIdx = nodeIdxEnd - 1 - nodeIdx;
+			uint backIdx = nodeIdxEnd - 1 - (nodeIdx - nodeIdxStart);
 			Node nodeBack = _NodeBuffer[backIdx];
 
 			if(nodeBack.time > 0)

--- a/Packages/GpuTrail/Shaders/GpuTrailCulling.compute
+++ b/Packages/GpuTrail/Shaders/GpuTrailCulling.compute
@@ -20,13 +20,38 @@ void UpdateTrailIdxBuffer (uint3 id : SV_DispatchThreadID)
 	{
 		uint nodeIdxStart = calcNodeIdx(trailIdx, 0);
 		uint nodeIdxEnd = nodeIdxStart + _NodeNumPerTrail;
-		for(uint nodeIdx = nodeIdxStart; nodeIdx < nodeIdxEnd; nodeIdx++)
+		uint nodeIdxEndHalf = nodeIdxStart + _NodeNumPerTrail / 2;
+		for(uint nodeIdx = nodeIdxStart; nodeIdx < nodeIdxEndHalf; nodeIdx++)
 		{
 			Node node = _NodeBuffer[nodeIdx];
+
 			if ( node.time > 0)
 			{
 				// CheckCulling!
 				float3 posFromCamera = node.pos - _CameraPos;
+
+				if ( 
+					/*
+					(dot(_CameraFrustumNormals[0], posFromCamera) > -_TrailWidth) 
+					&& (dot(_CameraFrustumNormals[1], posFromCamera) > -_TrailWidth)
+					&& (dot(_CameraFrustumNormals[2], posFromCamera) > -_TrailWidth)
+					&& (dot(_CameraFrustumNormals[3], posFromCamera) > -_TrailWidth)
+					*/
+					all(mul(_CameraFrustumNormals, posFromCamera) > -_TrailWidth)
+				)
+				{
+					_TrailIndexBufferAppend.Append(trailIdx);
+					break;
+				}
+			}
+
+			uint backIdx = nodeIdxEnd - 1 - nodeIdx;
+			Node nodeBack = _NodeBuffer[backIdx];
+
+			if(nodeBack.time > 0)
+			{
+				// CheckCulling!
+				float3 posFromCamera = nodeBack.pos - _CameraPos;
 
 				if ( 
 					/*

--- a/Packages/GpuTrail/Shaders/GpuTrailIndexInclude.hlsl
+++ b/Packages/GpuTrail/Shaders/GpuTrailIndexInclude.hlsl
@@ -22,9 +22,6 @@ inline uint GetTrailNum()
 
 #else
 
-
-#include "GpuTrailCSInclude.hlsl"
-
 inline uint GetTrailIdx(uint bufferIdx)
 {
 	return bufferIdx;

--- a/Packages/GpuTrail/Shaders/GpuTrailUpdateVertex.compute
+++ b/Packages/GpuTrail/Shaders/GpuTrailUpdateVertex.compute
@@ -10,7 +10,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 // UpdateVertex
 ////////////////////////////////////////////////////////////////////////////////
-StructuredBuffer<Trail> _TrailBuffer;
+RWStructuredBuffer<Trail> _TrailBuffer;
 StructuredBuffer<Node> _NodeBuffer;
 RWStructuredBuffer<Vertex> _VertexBuffer;
 
@@ -19,7 +19,8 @@ float3 _CameraPos;   // for perspective camera
 float _StartWidth;
 float _EndWidth;
 uint _LodNodeStep;
-
+int _FrameCount;
+bool _ForceUpdate;
 
 inline bool useToCameraDir()
 {
@@ -93,14 +94,26 @@ void UpdateVertex(uint3 id : SV_DispatchThreadID)
 		uint trailIdx = GetTrailIdx(trailIdxBufferIdx);
 
 		Trail trail = _TrailBuffer[trailIdx];
+
+		// Skip if no update required
+		if(!_ForceUpdate && _FrameCount == trail.frameCount && trail.selectedLod == _LodNodeStep)
+		{
+			return;
+		}
+
+		trail.frameCount = _FrameCount;
+		trail.selectedLod = _LodNodeStep;
+		_TrailBuffer[trailIdx] = trail;
+		
 		uint totalInputNum = trail.totalInputNum;
 
 		////////////////////////////////////////////////////////////
 		// Sequence newest node > oldest node
 		////////////////////////////////////////////////////////////
 		uint endNodeIdxInTrail = (totalInputNum - 1) % _NodeNumPerTrail;
-		uint vertexIdx = (((trailIdxBufferIdx+1) * (_NodeNumPerTrail / _LodNodeStep))-1) * 2;
-
+		// uint vertexIdx = (((trailIdxBufferIdx+1) * (_NodeNumPerTrail / _LodNodeStep))-1) * 2;
+		uint vertexIdx = (((trailIdx+1) * (_NodeNumPerTrail / _LodNodeStep))-1) * 2;
+			
 		Vertex v0 = GetDefaultVertex();
 		Vertex v1 = GetDefaultVertex();
 		uint count = _NodeNumPerTrail / _LodNodeStep;

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.18",
-    "com.unity.ide.visualstudio": "2.0.17",
+    "com.unity.ide.rider": "3.0.31",
+    "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
-    "com.unity.render-pipelines.universal": "14.0.6",
+    "com.unity.render-pipelines.universal": "14.0.8",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.ugui": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.burst": {
-      "version": "1.8.3",
+      "version": "1.8.8",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -17,7 +17,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.18",
+      "version": "3.0.31",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -26,7 +26,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.17",
+      "version": "2.0.18",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -49,7 +49,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
-      "version": "14.0.6",
+      "version": "14.0.8",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
@@ -60,14 +60,14 @@
       }
     },
     "com.unity.render-pipelines.universal": {
-      "version": "14.0.6",
+      "version": "14.0.8",
       "depth": 0,
       "source": "builtin",
       "dependencies": {
         "com.unity.mathematics": "1.2.1",
-        "com.unity.burst": "1.8.2",
-        "com.unity.render-pipelines.core": "14.0.6",
-        "com.unity.shadergraph": "14.0.6"
+        "com.unity.burst": "1.8.4",
+        "com.unity.render-pipelines.core": "14.0.8",
+        "com.unity.shadergraph": "14.0.8"
       }
     },
     "com.unity.searcher": {
@@ -78,11 +78,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.shadergraph": {
-      "version": "14.0.6",
+      "version": "14.0.8",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "14.0.6",
+        "com.unity.render-pipelines.core": "14.0.8",
         "com.unity.searcher": "4.9.2"
       }
     },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.2.10f1
-m_EditorVersionWithRevision: 2022.2.10f1 (bcebec703747)
+m_EditorVersion: 2022.3.10f1
+m_EditorVersionWithRevision: 2022.3.10f1 (ff3792e53c62)


### PR DESCRIPTION
GpuTrailRendererの機能拡張として、カメラごとの描画前に視錐台カリングをするようにしました。
これにより、TargetCameraが指定されていない場合でも、cullingEnable が true なら、GpuTrailの描画対象の全てのカメラでカリング処理を行うようになります。

``` C#
if (GraphicsSettings.currentRenderPipeline != null)
{
    RenderPipelineManager.beginCameraRendering += OnBeginCameraRendering;
}
else
{
    Camera.onPreCull += OnPreCullCallback;
}
```